### PR TITLE
Fix syntax error on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Reporting handled exceptions:
 
     begin
       raise "Something went wrong!"
-    rescue => exception
+    rescue exception
       Bugsnag.notify(exception)
     end
 


### PR DESCRIPTION
Hi 👋  - First of all, thank you for creating this shard/lib! ❤️ 

This is my first time working with Crystal 💎 

Testing this shard, I see an error when trying to run this snippet:
```
    require "bugsnag"

    begin
      raise "Something went wrong!"
    rescue => exception
      Bugsnag.notify(exception)
    end
```
 
![Screenshot 2023-02-08 at 6 55 55 PM](https://user-images.githubusercontent.com/5225249/217660201-f9025b2b-d750-4e30-adb5-dfa76e1c2084.png)

I only removed the `=>` operator and the error was fixed.

Feel free to close this pull request if there are other options to solve it 😊 
